### PR TITLE
memory leak and update bn performance

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/LocalOptimizerPerf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/LocalOptimizerPerf.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.dataset.{LocalDataSet, MiniBatch}
 import com.intel.analytics.bigdl.example.loadmodel.AlexNet
 import com.intel.analytics.bigdl.models.inception.{Inception_v1, Inception_v2}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
-import com.intel.analytics.bigdl.models.resnet.{ResNet, ResNet_50}
+import com.intel.analytics.bigdl.models.resnet.{ResNet}
 import com.intel.analytics.bigdl.models.resnet.ResNet.DatasetType
 import com.intel.analytics.bigdl.models.vgg.{Vgg_16, Vgg_19}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/MklDnnTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/MklDnnTensor.scala
@@ -20,6 +20,7 @@ import java.io.{IOException, ObjectInputStream}
 
 import com.intel.analytics.bigdl.mkl.{Memory, MklDnn}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import org.apache.log4j.{Level, Logger}
 import serialization.Bigdl.TensorType
 
 import scala.reflect.ClassTag
@@ -131,6 +132,18 @@ class MklDnnTensor[T: ClassTag](
 
 object MklDnnTensor {
   MklDnn.isLoaded
+
+  private val logger = Logger.getLogger(getClass)
+  logger.setLevel(Level.DEBUG)
+  private def backtrace(): Unit = {
+    logger.debug("BACKTRACE START NOW ---------------")
+    for (ste <- Thread.currentThread().getStackTrace) {
+      if (ste.toString.contains("com.intel.analytics.bigdl.nn")) {
+        logger.debug("\t|----> " + ste)
+      }
+    }
+  }
+
   def apply[T: ClassTag](size: Array[Int])(implicit ev: TensorNumeric[T]): MklDnnTensor[T] = {
     val storageOffset = 0
     val stride = DenseTensor.size2Stride(size)


### PR DESCRIPTION
1. Memory Leak
The internal buffer with MklDnnTensor should not be re-assigned without
releasing. So we should check it first. At first iteration or after the
changing of input size, we create a new MklDnnTensor as a buffer.

2. Bn perf
The JIT BatchNormalization only supports avx2 or avx512, which has much
batter performance than ref version. The input and gradOutput format
should be the same to get the best performance.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this patch)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

